### PR TITLE
ref: Add trace_id correlation to pytest setup/teardown

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,19 @@ By default ``pytest-sentry`` will send `Performance
 * Calls to the test function itself are reported as separate transaction such
   that you can find large, slow tests as well.
 
+* Fixture setup related to a particular test item will be in the same trace,
+  i.e. will have same trace ID. There is no common parent transaction though.
+  It is purposefully dropped to spare quota as it does not contain interesting
+  information::
+
+      pytest.runtest.protocol  [one time, not sent]
+        pytest.fixture.setup [multiple times, sent]
+        pytest.runtest.call [one time, sent]
+
+  The trace is per-test-item. For correlating transactions across an entire
+  test run, use the automatically attached CI tags or attach some tag on your
+  own.
+
 To measure performance data, install ``pytest-sentry`` and set
 ``PYTEST_SENTRY_DSN``, like with errors.
 

--- a/pytest_sentry.py
+++ b/pytest_sentry.py
@@ -178,7 +178,8 @@ def pytest_runtest_call(item):
 @hookwrapper(itemgetter=lambda fixturedef, request: request._pyfuncitem)
 def pytest_fixture_setup(fixturedef, request):
     op = "pytest.fixture.setup"
-    with _start_transaction(op=op, name=u"{} {}".format(op, fixturedef.argname)):
+    with _start_transaction(op=op, name=u"{} {}".format(op, fixturedef.argname)) as transaction:
+        transaction.set_tag("pytest.fixture.scope", fixturedef.scope)
         yield
 
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -44,3 +44,12 @@ def assert_report():
         test_transaction["transaction"]
         == "pytest.runtest.call tests/test_tracing.py::test_basic"
     )
+
+    assert (
+        fixture_transaction["contexts"]["trace"]["trace_id"]
+        == test_transaction["contexts"]["trace"]["trace_id"]
+    )
+    assert (
+        self_transaction["contexts"]["trace"]["trace_id"]
+        == fixture_transaction["contexts"]["trace"]["trace_id"]
+    )


### PR DESCRIPTION
Fix #10 

Deciding against linking entire test run together via trace_id for now to reduce trace size.