### PR TITLE
Use SPDX license expression in project metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     long_description=open("README.rst").read(),
     author="Markus Unterwaditzer",
     version="0.1.9",
-    license="BSD",
+    license="BSD-2-Clause",
     author_email="markus@unterwaditzer.net",
     url="https://github.com/untitaker/pytest-sentry",
     py_modules=["pytest_sentry"],


### PR DESCRIPTION
As a downstream user it is desirable to be able to programmatically determine the precise licenses used by our dependencies. The emerging convention for this is the [SPDX License List](https://spdx.org/licenses/). SPDX License Expressions are already used in the JavaScript (npm) and Rust (crates.io) ecosystems, for example.

In Python, there is [PEP 639](https://peps.python.org/pep-0639/) which would add a standard 'License-Expression' metadata field. The discussion around this PEP seems to have gone stale in 2021.

This merge request is in lieu of that PEP coming soon. Unless you as project maintainers think the proposed change in this PR has downsides (which you are entitled to!), I would ask that you accept this change so that it's possible for users to attempt to parse your license metadata as an SPDX License Expression.

In particular, it disambiguates which BSD license it is.