### PR TITLE
feat: Add an env override for the traces sample rate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,11 @@ By default ``pytest-sentry`` will send `Performance
   own.
 
 To measure performance data, install ``pytest-sentry`` and set
-``PYTEST_SENTRY_DSN``, like with errors.
+``PYTEST_SENTRY_DSN``, like with errors. By default, the extension will send all
+performance data to Sentry. If you want to limit the amount of data sent, you
+can set the ``PYTEST_SENTRY_TRACES_SAMPLE_RATE`` environment variable to a float
+between ``0`` and ``1``. This will cause only a random sample of transactions to
+be sent to Sentry.
 
 Transactions can have noticeable runtime overhead over just reporting errors.
 To disable, use a marker::

--- a/pytest_sentry.py
+++ b/pytest_sentry.py
@@ -82,7 +82,7 @@ class PytestIntegration(Integration):
 class Client(sentry_sdk.Client):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("dsn", os.environ.get("PYTEST_SENTRY_DSN", None))
-        kwargs.setdefault("traces_sample_rate", 1.0)
+        kwargs.setdefault("traces_sample_rate", os.environ.get("PYTEST_SENTRY_TRACES_SAMPLE_RATE", 1.0))
         kwargs.setdefault("_experiments", {}).setdefault(
             "auto_enabling_integrations", True
         )

--- a/pytest_sentry.py
+++ b/pytest_sentry.py
@@ -82,7 +82,7 @@ class PytestIntegration(Integration):
 class Client(sentry_sdk.Client):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("dsn", os.environ.get("PYTEST_SENTRY_DSN", None))
-        kwargs.setdefault("traces_sample_rate", os.environ.get("PYTEST_SENTRY_TRACES_SAMPLE_RATE", 1.0))
+        kwargs.setdefault("traces_sample_rate", float(os.environ.get("PYTEST_SENTRY_TRACES_SAMPLE_RATE", 1.0)))
         kwargs.setdefault("_experiments", {}).setdefault(
             "auto_enabling_integrations", True
         )


### PR DESCRIPTION
This makes the traces sample rate configurable and leaves it at 100% by default.