### PR TITLE
Resolve the iterator outside of the hub context to not mess with the state of the RNG

### DIFF
--- a/pytest_sentry.py
+++ b/pytest_sentry.py
@@ -113,8 +113,7 @@ def hookwrapper(itemgetter, **kwargs):
 
             while True:
                 try:
-                    with hub:
-                        chunk = next(gen)
+                    chunk = next(gen)
 
                     y = yield chunk
 


### PR DESCRIPTION
Hi. We're making use of this pytest fixture:

```python
@pytest.fixture(autouse=True)
def determinism(request: Any) -> None:
    """Re-seed the RNG differently for every test."""
    random.seed(request.module.__name__ + request.node.name)
```

We also make use of https://pypi.org/project/pytest-snapshot/. And when `pytest-sentry` is installed, it breaks our tests because somehow the RNG state gets modified.

This PR fixes our problem and I'm wondering if it's also an acceptable default for everyone.

If not, could we have a way to configure pytest-sentry so that we don't have to use a fork?
