### PR TITLE
build: Add `-e .` to `dev-requirements.txt`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,25 +8,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python }}
-      - run: pip install -r dev-requirements.txt
-      - run: PYTEST_SENTRY_ALWAYS_REPORT=1 pytest tests
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python }}
+    - run: pip install -r dev-requirements.txt
+    - run: PYTEST_SENTRY_ALWAYS_REPORT=1 pytest tests
   dist:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.x"
-      - run: |
-          pip install build
-          python -m build
-      - uses: actions/upload-artifact@v3
-        with:
-          name: ${{ github.sha }}
-          path: dist/*
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - run: |
+        pip install build
+        python -m build
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.sha }}
+        path: dist/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,25 +8,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python }}
-    - run: pip install -e . -r dev-requirements.txt
-    - run: PYTEST_SENTRY_ALWAYS_REPORT=1 pytest tests
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+      - run: pip install -r dev-requirements.txt
+      - run: PYTEST_SENTRY_ALWAYS_REPORT=1 pytest tests
   dist:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-    - run: |
-        pip install build
-        python -m build
-    - uses: actions/upload-artifact@v3
-      with:
-        name: ${{ github.sha }}
-        path: dist/*
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - run: |
+          pip install build
+          python -m build
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.sha }}
+          path: dist/*

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
+-e .
 pytest-rerunfailures
 pytest<4; python_version < '3.0'


### PR DESCRIPTION
It is necessary to install `-e .` to run the tests and to get type hints while working on the project; therefore `-e .` should be included in `dev-requirements.txt`.