### PR TITLE
Revert generator logic and fix isolation scope creation

### DIFF
--- a/pytest_sentry/helpers.py
+++ b/pytest_sentry/helpers.py
@@ -41,25 +41,25 @@ def _resolve_scope_marker_value_uncached(marker_value):
 
     if isinstance(marker_value, str):
         # If a DSN string is provided, create a new client and use that
-        scope = sentry_sdk.get_isolation_scope()
+        scope = sentry_sdk.Scope(ty=ScopeType.ISOLATION)
         scope.set_client(Client(marker_value))
         return scope
 
     if isinstance(marker_value, dict):
         # If a dict is provided, create a new client using the dict as Client options
-        scope = sentry_sdk.get_isolation_scope()
+        scope = sentry_sdk.Scope(ty=ScopeType.ISOLATION)
         scope.set_client(Client(**marker_value))
         return scope
 
     if isinstance(marker_value, Client):
         # If a Client instance is provided, use that
-        scope = sentry_sdk.get_isolation_scope()
+        scope = sentry_sdk.Scope(ty=ScopeType.ISOLATION)
         scope.set_client(marker_value)
         return scope
 
     if isinstance(marker_value, sentry_sdk.Scope):
         # If a Scope instance is provided, use the client from it
-        scope = sentry_sdk.get_isolation_scope()
+        scope = sentry_sdk.Scope(ty=ScopeType.ISOLATION)
         scope.set_client(marker_value.client)
         return marker_value
 

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -25,11 +25,6 @@ def test_basic():
     _assert_right_scopes()
 
 
-def test_correct_span():
-    # Ensure that we are within a root span (started by the pytest_runtest_call hook)
-    assert sentry_sdk.get_current_scope().span is not None
-
-
 class TestSimpleClass(object):
     def setup_method(self):
         _assert_right_scopes()


### PR DESCRIPTION
The main yield has to be outside the `use_isolation_scope` blocks because otherwise stuff in the test logic will use the pytest Client and report errors and exceptions too causing a regression.

closes #43 